### PR TITLE
Specify an html tokenizer when calling linkify.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
     url='http://www.github.com/dcramer/py-wikimarkup/',
     zip_safe=False,
     include_package_data=True,
-    install_requires=['bleach'],
+    install_requires=['bleach>=1.1.4'],
     package_data = { '': ['README.rst'] },
 )

--- a/wikimarkup/parser.py
+++ b/wikimarkup/parser.py
@@ -23,6 +23,8 @@ from base64 import b64encode, b64decode
 
 import bleach
 
+from html5lib.tokenizer import HTMLTokenizer
+
 # a few patterns we use later
 
 MW_COLON_STATE_TEXT = 0
@@ -1711,7 +1713,7 @@ class Parser(BaseParser):
         if utf8:
             text.encode("utf-8")
         # Pass output through bleach and linkify
-        text = bleach.linkify(text, nofollow=nofollow)
+        text = bleach.linkify(text, nofollow=nofollow, tokenizer=HTMLTokenizer)
         return bleach.clean(text, tags=self.tags, attributes=attributes,
                             styles=styles, strip_comments=False)
 


### PR DESCRIPTION
This will only work with bleach v1.1.4 and up, and is needed in bleach >1.0.3. It prevents unknown tags from being unfairly escaped during the linkify step (which causes problems).
